### PR TITLE
embed/viewer.go: close viewer with escape key

### DIFF
--- a/components/embed/viewer.go
+++ b/components/embed/viewer.go
@@ -151,6 +151,17 @@ func NewViewer(ctx context.Context, uri string, opts Opts) (*Viewer, error) {
 
 	v.SetContent(box)
 
+	esc := gtk.NewEventControllerKey()
+	esc.setName("viewer-escape")
+	esc.ConnectKeyPressed(func(val, _ uint, state gdk.ModifierType) bool {
+		switch val {
+		case gdk.KEY_Escape:
+			v.Close()
+			return true
+		}
+		return false
+	})
+
 	gtkutil.BindActionMap(v, map[string]func(){
 		"embedviewer.close":         v.close,
 		"embedviewer.download":      v.download,


### PR DESCRIPTION
This MR adds a binding to close the viewer with the escape key, as described in #2 and resolving diamondburned/dissent#236.